### PR TITLE
changes I needed to make to get this role to work with bundle installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Install this role alongside the roles used by the Anisble Tower installer (bundl
 
 ```
 ansible-galaxy install samdoran.postgresql-replication -p roles
-ansible-playbook -b -i inventory psql-replication.yml
+ansible-playbook -b -i inventory psql-replication.yml -e 'pg_version=9.6'
 ```
 
 ```yaml
@@ -89,6 +89,9 @@ ansible-playbook -b -i inventory psql-replication.yml
         - always
 
   roles:
+    - role: repos_el
+      when: bundle_install
+
     - role: packages_el
       packages_el_install_tower: false
       packages_el_install_postgres: true

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -24,3 +24,6 @@
     line: "{{ item.line }}"
   with_items: "{{ postgresrep_pg_hba_conf_lines }}"
   notify: restart postgresql
+
+- name: force all notified handlers to run at this point, not waiting for normal sync points
+  meta: flush_handlers


### PR DESCRIPTION
@AJEastwood I used your changes, plus these changes to get this role to work with `ansible-tower-setup-bundle-3.2.2-1.el7`

Without passing in the value for `pg_version` as an extra var, the example playbook would fail to run due to undeclared variable, even though `pg_version` is defined in the role itself.

Without `- role: repos_el` my slave did not have any of the file based repos to install postgresql96-server.

Without `meta: flush_handlers` the setup of the streaming replication would fail as the ACL defined in pg_hba.conf on the master would not be live, therefore causing a connection denied failure. Forcing the restart fixes the issue.
